### PR TITLE
feat: add Server酱³ (ServerChan3) notification channel with multi-key support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,6 +82,12 @@ notify:
     # Server酱 SendKey 通道密钥
     send_key: ""
 
+  # ---------- Server酱³ ----------
+  serverchan3:
+    # Server酱³ SendKey（格式为 sctp{uid}t...，与 Turbo 版 SCT key 不通用）
+    # 可在 https://sc3.ft07.com/sendkey 获取
+    send_key: ""
+
   # ---------- Bark ----------
   bark:
     # Bark 设备 Key，可在 Bark App 中查看

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,9 +84,13 @@ notify:
 
   # ---------- Server酱³ ----------
   serverchan3:
-    # Server酱³ SendKey（格式为 sctp{uid}t...，与 Turbo 版 SCT key 不通用）
+    # 单个 SendKey（格式为 sctp{uid}t...，与 Turbo 版 SCT key 不通用）
     # 可在 https://sc3.ft07.com/sendkey 获取
     send_key: ""
+    # 多用户推送：使用 send_keys 列表代替 send_key（两者填一个即可）
+    # send_keys:
+    #   - "sctp123tXXXXXXXXXXXXXXXX"
+    #   - "sctp456tYYYYYYYYYYYYYYYY"
 
   # ---------- Bark ----------
   bark:

--- a/notifier.py
+++ b/notifier.py
@@ -43,6 +43,9 @@ class NotifierManager:
         if notify_cfg.get("serverchan", {}).get("send_key"):
             self.notifiers.append(ServerChanNotifier(notify_cfg["serverchan"]))
 
+        if notify_cfg.get("serverchan3", {}).get("send_key"):
+            self.notifiers.append(ServerChan3Notifier(notify_cfg["serverchan3"]))
+
         bark_cfg = notify_cfg.get("bark", {})
         if bark_cfg.get("key") or bark_cfg.get("device_key") or bark_cfg.get("device_keys"):
             self.notifiers.append(BarkNotifier(bark_cfg))
@@ -377,4 +380,44 @@ class BarkNotifier(BaseNotifier):
                 return True
 
             logger.error(f"[Bark] 推送失败: {result.get('message') or result}")
+            return False
+
+
+# ==================== Server酱³ ====================
+class ServerChan3Notifier(BaseNotifier):
+    name = "ServerChan3"
+
+    def __init__(self, cfg: dict):
+        self.send_key = cfg["send_key"]
+        # 从 sendkey 中提取 uid 以构造 SC3 专属推送地址
+        # sendkey 格式: sctp{uid}t...
+        import re
+        match = re.match(r"sctp(\d+)t", self.send_key)
+        if match:
+            uid = match.group(1)
+            self.url = f"https://{uid}.push.ft07.com/send/{self.send_key}.send"
+        else:
+            # 回退到 Turbo 兼容地址（旧版 SCT key）
+            self.url = f"https://sctapi.ftqq.com/{self.send_key}.send"
+
+    async def send(self, message: str) -> bool:
+        lines = message.split("\n")
+        title = lines[0] if lines else "森空岛签到通知"
+        desp = "\n".join(lines[1:]).strip() if len(lines) > 1 else ""
+
+        payload = {"title": title, "desp": desp}
+        headers = {"Content-Type": "application/json;charset=utf-8"}
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(self.url, json=payload, headers=headers, timeout=10)
+                result = resp.json()
+                if result.get("code") == 0:
+                    logger.info("[ServerChan3] 推送成功")
+                    return True
+                else:
+                    logger.error(f"[ServerChan3] 推送失败: {result.get('message')}")
+                    return False
+        except Exception as e:
+            logger.error(f"[ServerChan3] 推送异常: {e}")
             return False

--- a/notifier.py
+++ b/notifier.py
@@ -43,8 +43,9 @@ class NotifierManager:
         if notify_cfg.get("serverchan", {}).get("send_key"):
             self.notifiers.append(ServerChanNotifier(notify_cfg["serverchan"]))
 
-        if notify_cfg.get("serverchan3", {}).get("send_key"):
-            self.notifiers.append(ServerChan3Notifier(notify_cfg["serverchan3"]))
+        sc3_cfg = notify_cfg.get("serverchan3", {})
+        if sc3_cfg.get("send_key") or sc3_cfg.get("send_keys"):
+            self.notifiers.append(ServerChan3Notifier(sc3_cfg))
 
         bark_cfg = notify_cfg.get("bark", {})
         if bark_cfg.get("key") or bark_cfg.get("device_key") or bark_cfg.get("device_keys"):
@@ -388,36 +389,49 @@ class ServerChan3Notifier(BaseNotifier):
     name = "ServerChan3"
 
     def __init__(self, cfg: dict):
-        self.send_key = cfg["send_key"]
-        # 从 sendkey 中提取 uid 以构造 SC3 专属推送地址
-        # sendkey 格式: sctp{uid}t...
+        # 支持单个 send_key 或多个 send_keys 列表
+        raw = cfg.get("send_keys") or cfg.get("send_key", "")
+        if isinstance(raw, str):
+            self.send_keys = [k.strip() for k in raw.split(",") if k.strip()]
+        elif isinstance(raw, list):
+            self.send_keys = [str(k).strip() for k in raw if str(k).strip()]
+        else:
+            self.send_keys = []
+
+    @staticmethod
+    def _build_url(send_key: str) -> str:
         import re
-        match = re.match(r"sctp(\d+)t", self.send_key)
+        match = re.match(r"sctp(\d+)t", send_key)
         if match:
             uid = match.group(1)
-            self.url = f"https://{uid}.push.ft07.com/send/{self.send_key}.send"
-        else:
-            # 回退到 Turbo 兼容地址（旧版 SCT key）
-            self.url = f"https://sctapi.ftqq.com/{self.send_key}.send"
+            return f"https://{uid}.push.ft07.com/send/{send_key}.send"
+        # 回退到 Turbo 兼容地址（旧版 SCT key）
+        return f"https://sctapi.ftqq.com/{send_key}.send"
 
     async def send(self, message: str) -> bool:
+        if not self.send_keys:
+            logger.error("[ServerChan3] 未配置 send_key")
+            return False
+
         lines = message.split("\n")
         title = lines[0] if lines else "森空岛签到通知"
         desp = "\n".join(lines[1:]).strip() if len(lines) > 1 else ""
-
         payload = {"title": title, "desp": desp}
         headers = {"Content-Type": "application/json;charset=utf-8"}
 
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.post(self.url, json=payload, headers=headers, timeout=10)
-                result = resp.json()
-                if result.get("code") == 0:
-                    logger.info("[ServerChan3] 推送成功")
-                    return True
-                else:
-                    logger.error(f"[ServerChan3] 推送失败: {result.get('message')}")
-                    return False
-        except Exception as e:
-            logger.error(f"[ServerChan3] 推送异常: {e}")
-            return False
+        all_success = True
+        async with httpx.AsyncClient() as client:
+            for key in self.send_keys:
+                try:
+                    url = self._build_url(key)
+                    resp = await client.post(url, json=payload, headers=headers, timeout=10)
+                    result = resp.json()
+                    if result.get("code") == 0:
+                        logger.info(f"[ServerChan3] 推送成功 -> {key[:8]}...")
+                    else:
+                        logger.error(f"[ServerChan3] 推送失败 -> {key[:8]}...: {result.get('message')}")
+                        all_success = False
+                except Exception as e:
+                    logger.error(f"[ServerChan3] 推送异常 -> {key[:8]}...: {e}")
+                    all_success = False
+        return all_success


### PR DESCRIPTION
## Summary

Add [Server酱³ (ServerChan3)](https://sc3.ft07.com/) as a new notification channel alongside the existing ServerChan Turbo integration.

## Changes

- **`notifier.py`** — Added `ServerChan3Notifier` class:
  - Automatically extracts `uid` from the SendKey (format `sctp{uid}t...`) to construct the correct push endpoint (`https://{uid}.push.ft07.com/send/{sendkey}.send`)
  - Falls back to the legacy Turbo-compatible URL for old-format SCT keys
  - Supports pushing to **multiple recipients** via a `send_keys` list or a single `send_key` string; each key is pushed independently with per-key logging

- **`config.example.yaml`** — Added `notify.serverchan3` configuration block with inline comments explaining the SendKey format, where to obtain it, and how to configure multiple keys

## Configuration

```yaml
notify:
  serverchan3:
    # Single recipient
    send_key: "sctp123tXXXXXXXXXXXXXXXX"

    # Multiple recipients (use either send_key or send_keys, not both)
    # send_keys:
    #   - "sctp123tXXXXXXXXXXXXXXXX"
    #   - "sctp456tYYYYYYYYYYYYYYYY"